### PR TITLE
Update Discord RPC to v3.3.0 and fix metadata double click bug

### DIFF
--- a/foo_drpc/Plugin.cpp
+++ b/foo_drpc/Plugin.cpp
@@ -93,9 +93,9 @@ void foo_drpc::on_playback_stop(playback_control::t_stop_reason reason)
 	case playback_control::stop_reason_shutting_down:
 		discordPresence.state = "Stopped";
 		discordPresence.smallImageKey = "stop";
+		updateDiscordPresence();
 		break;
 	}
-	updateDiscordPresence();
 }
 
 void foo_drpc::on_playback_pause(bool pause)
@@ -186,7 +186,7 @@ void foo_drpc::updateDiscordPresence()
 	Discord_RunCallbacks();
 }
 
-void connectedF()
+void connectedF(const DiscordUser* request)
 {
 	connected = true;
 }


### PR DESCRIPTION
This pull request solves two issues at the same time.

The first issue is that foo_drpc no longer compiles using the latest Discord RPC released in April - Discord RPC version 3.3.0, since the ready handler now expects a DiscordUser struct in the callback.

The second issue is that clicking on another song while a song is already running will NOT update the song's name.

This happens because of the spam protection. When switching to another song, the first song is paused and then the next song is started. However, everytime a song is paused, foo_drpc always sends an RPC update, even when not necessary. This results in the RPC request responsible for updating the song's name to never send, because of the 0.42s spam protection. These two events always happen at the same time.

We can resolve that issue by only updating the Discord RPC when absolutely necessary during song pausing.

Please note that it will be necessary to compile foo_drpc with the latest Discord RPC version 3.3.0. Older versions are now incompatible.

Fixes issue #3 and #5.